### PR TITLE
Adafruit TSL2591 light sensor support

### DIFF
--- a/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
+++ b/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
@@ -29,7 +29,7 @@ int steps_remaining[n_motors];
 const int INPUT_BUFFER_LENGTH = 64;
 char input_buffer[INPUT_BUFFER_LENGTH];
 
-int command_prefix(String command, const char ** prefixes, int n_prefixes){
+int command_prefix(String command, char ** prefixes, int n_prefixes){
   // Check if the command starts with any of the prefixes in the list.
   // returns the index if so, otherwise returns -1
   for(int i=0; i<n_prefixes; i++){
@@ -192,9 +192,13 @@ void loop() {
     }
     if(command.startsWith("ramp_time ")){
       int preceding_space = command.indexOf(' ',0);
-      if(preceding_space <= 0) Serial.println("Bad command.");
+      if(preceding_space <= 0){
+        Serial.println("Bad command.");
+        return;
+      }
       ramp_time = command.substring(preceding_space+1).toInt();
       EEPROM.put(ramp_time_eeprom, ramp_time);
+      Serial.println("done.");
       return;
     }
     if(command.startsWith("ramp_time?")){
@@ -204,9 +208,13 @@ void loop() {
     }
     if(command.startsWith("min_step_delay ") || command.startsWith("dt ")){
       int preceding_space = command.indexOf(' ',0);
-      if(preceding_space <= 0) Serial.println("Bad command.");
+      if(preceding_space <= 0){
+        Serial.println("Bad command.");
+        return;
+      }
       min_step_delay = command.substring(preceding_space+1).toInt();
       EEPROM.put(min_step_delay_eeprom, min_step_delay);
+      Serial.println("done.");
       return;
     }
     if(command.startsWith("min_step_delay?") || command.startsWith("dt?")){

--- a/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
+++ b/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
@@ -177,7 +177,7 @@ void setup_light_sensor(){
 
 void print_light_sensor_gain(){
   // Print the current gain value of the light sensor
-  Serial.print  (F("Gain: "));
+  Serial.print  (F("light sensor gain: "));
   tsl2591Gain_t gain = tsl.getGain();
   switch(gain)
   {
@@ -220,7 +220,7 @@ void set_light_sensor_gain(int newgain){
 
 void print_light_sensor_integration_time(){
   // Print the current integration time in milliseconds.
-  Serial.print  (F("Timing:       "));
+  Serial.print  (F("light sensor integration time: "));
   Serial.print((tsl.getTiming() + 1) * 100, DEC); 
   Serial.println(F(" ms"));
 }

--- a/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
+++ b/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
@@ -13,7 +13,7 @@
 #include <assert.h>
 #include <EEPROM.h>
 
-#define ADAFRUIT_TSL2591_SUPPORT
+//#define ADAFRUIT_TSL2591_SUPPORT
 
 #ifdef ADAFRUIT_TSL2591_SUPPORT
 #include <Wire.h>
@@ -355,14 +355,16 @@ void loop() {
       Serial.println(F("ramp_time? - get the time taken to accelerate/decelerate in us"));
       Serial.println(F("min_step_delay? - get the minimum time between steps in us."));
       Serial.println(F("zero - set the current position to zero."));
+      #ifdef ADAFRUIT_TSL2591_SUPPORT
       Serial.println(F("light_sensor_gain ??? - set the gain of the light sensor"));
       Serial.println(F("light_sensor_gain? - get the gain of the light sensor"));
       Serial.println(F("light_sensor_integration_time? - get the integration time in milliseconds"));
       Serial.println(F("light_sensor_fullspectrum? - read the current value from the full spectrum diode"));
+      #endif
       Serial.println("");
       Serial.println(F("??? means a decimal integer."));
     }
-    Serial.println(F("Type help for a list of commands."));
+    Serial.println(F("Type 'help' for a list of commands."));
   }else{
     delay(1);
     return;

--- a/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
+++ b/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
@@ -13,6 +13,14 @@
 #include <assert.h>
 #include <EEPROM.h>
 
+#define ADAFRUIT_TSL2591_SUPPORT
+
+#ifdef ADAFRUIT_TSL2591_SUPPORT
+#include <Wire.h>
+#include <Adafruit_Sensor.h>
+#include "Adafruit_TSL2591.h"
+#endif
+
 #define EACH_MOTOR for(int i=0; i<n_motors; i++)
 
 // The array below has 3 stepper objects, for X,Y,Z respectively
@@ -29,7 +37,7 @@ int steps_remaining[n_motors];
 const int INPUT_BUFFER_LENGTH = 64;
 char input_buffer[INPUT_BUFFER_LENGTH];
 
-int command_prefix(String command, char ** prefixes, int n_prefixes){
+int command_prefix(String command, const char ** prefixes, int n_prefixes){
   // Check if the command starts with any of the prefixes in the list.
   // returns the index if so, otherwise returns -1
   for(int i=0; i<n_prefixes; i++){
@@ -63,6 +71,14 @@ void setup() {
     EEPROM.put(min_step_delay_eeprom, min_step_delay); 
   }
   EEPROM.get(ramp_time_eeprom, ramp_time);
+  if(ramp_time < 0){ // -1 seems to be what we get if it's uninitialised.
+    ramp_time = 0;
+    EEPROM.put(ramp_time_eeprom, ramp_time); 
+  }
+  #ifdef ADAFRUIT_TSL2591_SUPPORT
+  setup_light_sensor();
+  #endif
+  
 }
 
 void stepMotor(int motor, int dx){
@@ -143,6 +159,79 @@ void move_axes(int displacement[n_motors]){
     EEPROM.put(0, current_pos);
 }
 
+#ifdef ADAFRUIT_TSL2591_SUPPORT
+Adafruit_TSL2591 tsl = Adafruit_TSL2591(2591); // pass in a number for the sensor identifier (for your use later)
+
+void setup_light_sensor(){
+  if (tsl.begin()) 
+  {
+    Serial.println(F("Found a TSL2591 sensor"));
+    tsl.setGain(TSL2591_GAIN_MED);
+    tsl.setTiming(TSL2591_INTEGRATIONTIME_100MS);  // shortest integration time (bright light)
+  } 
+  else 
+  {
+    Serial.println(F("No light sensor found.  NB your board will start up faster if you recompile without light sensor support."));
+  }
+}
+
+void print_light_sensor_gain(){
+  // Print the current gain value of the light sensor
+  Serial.print  (F("Gain: "));
+  tsl2591Gain_t gain = tsl.getGain();
+  switch(gain)
+  {
+    case TSL2591_GAIN_LOW:
+      Serial.println(F("1x (Low)"));
+      break;
+    case TSL2591_GAIN_MED:
+      Serial.println(F("25x (Medium)"));
+      break;
+    case TSL2591_GAIN_HIGH:
+      Serial.println(F("428x (High)"));
+      break;
+    case TSL2591_GAIN_MAX:
+      Serial.println(F("9876x (Max)"));
+      break;
+  }
+}
+
+void set_light_sensor_gain(int newgain){
+  // Set the current gain value of the light sensor, and print a confirmation.
+  switch(newgain){
+    case 1:
+      tsl.setGain(TSL2591_GAIN_LOW);
+      break;
+    case 25:
+      tsl.setGain(TSL2591_GAIN_MED);
+      break;
+    case 428:
+      tsl.setGain(TSL2591_GAIN_HIGH);
+      break;
+    case 9876:
+      tsl.setGain(TSL2591_GAIN_MAX);
+      break;
+    default:
+      Serial.println(F("Error: gain may only be 1, 25, 428, or 9876."));
+      return;
+  }
+  print_light_sensor_gain();
+}
+
+void print_light_sensor_integration_time(){
+  // Print the current integration time in milliseconds.
+  Serial.print  (F("Timing:       "));
+  Serial.print((tsl.getTiming() + 1) * 100, DEC); 
+  Serial.println(F(" ms"));
+}
+
+void print_light_sensor_fullspectrum(){
+  // Print the current light value
+  uint16_t x = tsl.getLuminosity(TSL2591_FULLSPECTRUM);
+  Serial.println(x, DEC);
+}
+
+#endif
 
 void loop() {
   // wait for a serial command and read it
@@ -171,7 +260,7 @@ void loop() {
       EACH_MOTOR{ //read three integers and store in steps_remaining
         preceding_space = command.indexOf(' ',preceding_space+1);
         if(preceding_space<0){
-          Serial.println("Error: command is mr <int> <int> <int>");
+          Serial.println(F("Error: command is mr <int> <int> <int>"));
           break;
         }
         displacement[i] = command.substring(preceding_space+1).toInt();
@@ -228,24 +317,52 @@ void loop() {
       EEPROM.put(0, current_pos);
       return;
     }
-    if(command.startsWith("help")){
-      Serial.println("OpenFlexure Motor Controller firmware v0.1");
-      Serial.println("Commands (terminated by a newline character):");
-      Serial.println("mrx ??? - relative move in x");
-      Serial.println("mrx ??? - relative move in x");
-      Serial.println("mrx ??? - relative move in x");
-      Serial.println("mr ??? ??? ??? - relative move in all 3 axes");
-      Serial.println("release - de-energise all motors");
-      Serial.println("p? - print position (3 space-separated integers");
-      Serial.println("ramp_time ??? - set the time taken to accelerate/decelerate in us");
-      Serial.println("min_step_delay ??? - set the minimum time between steps in us.");
-      Serial.println("dt ??? - set the minimum time between steps in us.");
-      Serial.println("ramp_time? - get the time taken to accelerate/decelerate in us");
-      Serial.println("min_step_delay? - get the minimum time between steps in us.");
-      Serial.println("zero - set the current position to zero.");
-      Serial.println("??? means a decimal integer.");
+    #ifdef ADAFRUIT_TSL2591_SUPPORT
+    if(command.startsWith("light_sensor_gain?")){
+      print_light_sensor_gain();
+      return;
     }
-    Serial.println("Type help for a list of commands.");
+    if(command.startsWith("light_sensor_gain ")){
+      int preceding_space = command.indexOf(' ',0);
+      if(preceding_space <= 0){
+        Serial.println("Bad command.");
+        return;
+      }
+      set_light_sensor_gain(command.substring(preceding_space+1).toInt());
+      return;
+    }
+    if(command.startsWith("light_sensor_integration_time?")){
+      print_light_sensor_integration_time();
+      return;
+    }
+    if(command.startsWith("light_sensor_fullspectrum?")){
+      print_light_sensor_fullspectrum();
+      return;
+    }
+    #endif
+    if(command.startsWith("help")){
+      Serial.println(F("OpenFlexure Motor Controller firmware v0.1"));
+      Serial.println(F("Commands (terminated by a newline character):"));
+      Serial.println(F("mrx ??? - relative move in x"));
+      Serial.println(F("mrx ??? - relative move in x"));
+      Serial.println(F("mrx ??? - relative move in x"));
+      Serial.println(F("mr ??? ??? ??? - relative move in all 3 axes"));
+      Serial.println(F("release - de-energise all motors"));
+      Serial.println(F("p? - print position (3 space-separated integers"));
+      Serial.println(F("ramp_time ??? - set the time taken to accelerate/decelerate in us"));
+      Serial.println(F("min_step_delay ??? - set the minimum time between steps in us."));
+      Serial.println(F("dt ??? - set the minimum time between steps in us."));
+      Serial.println(F("ramp_time? - get the time taken to accelerate/decelerate in us"));
+      Serial.println(F("min_step_delay? - get the minimum time between steps in us."));
+      Serial.println(F("zero - set the current position to zero."));
+      Serial.println(F("light_sensor_gain ??? - set the gain of the light sensor"));
+      Serial.println(F("light_sensor_gain? - get the gain of the light sensor"));
+      Serial.println(F("light_sensor_integration_time? - get the integration time in milliseconds"));
+      Serial.println(F("light_sensor_fullspectrum? - read the current value from the full spectrum diode"));
+      Serial.println("");
+      Serial.println(F("??? means a decimal integer."));
+    }
+    Serial.println(F("Type help for a list of commands."));
   }else{
     delay(1);
     return;

--- a/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
+++ b/arduino_code/openflexure_nano_motor_controller/openflexure_nano_motor_controller.ino
@@ -177,7 +177,7 @@ void setup_light_sensor(){
 
 void print_light_sensor_gain(){
   // Print the current gain value of the light sensor
-  Serial.print  (F("light sensor gain: "));
+  Serial.print  (F("light sensor gain "));
   tsl2591Gain_t gain = tsl.getGain();
   switch(gain)
   {
@@ -220,7 +220,7 @@ void set_light_sensor_gain(int newgain){
 
 void print_light_sensor_integration_time(){
   // Print the current integration time in milliseconds.
-  Serial.print  (F("light sensor integration time: "));
+  Serial.print  (F("light sensor integration time "));
   Serial.print((tsl.getTiming() + 1) * 100, DEC); 
   Serial.println(F(" ms"));
 }

--- a/python_code/README.md
+++ b/python_code/README.md
@@ -1,0 +1,3 @@
+# Python Scripts
+
+The Python scripts in this folder provide a convenient way to control the motors - they come from the [openflexure microscope software](https://github.com/rwb27/openflexure_microscope_software/) repository, and it is possible that I should remove them from here and leave them there.  It is worth checking that repo in case there are more up-to-date versions there.

--- a/python_code/openflexure_stage.py
+++ b/python_code/openflexure_stage.py
@@ -5,21 +5,86 @@ Created on Sun Jun 18 21:06:04 2017
 @author: richa
 """
 
-import nplab
-import nplab.instrument.serial_instrument
 import time
-from basic_serial_instrument import BasicSerialInstrument, QueriedProperty
+from basic_serial_instrument import BasicSerialInstrument, QueriedProperty, EIGHTBITS, PARITY_NONE, STOPBITS_ONE
 import numpy as np
 
 class OpenFlexureStage(BasicSerialInstrument):
-    port_settings = {'baudrate':115200}
+    port_settings = {'baudrate':115200, 'bytesize':EIGHTBITS, 'parity':PARITY_NONE, 'stopbits':STOPBITS_ONE}
+    # position, step time and ramp time are get/set using simple serial
+    # commands.
     position = QueriedProperty(get_cmd="p?", response_string=r"%d %d %d")
     step_time = QueriedProperty(get_cmd="dt?", set_cmd="dt %d", response_string="minimum step delay %d")
     ramp_time = QueriedProperty(get_cmd="ramp_time?", set_cmd="ramp_time %d", response_string="ramp time %d")
+    axis_names = ('x', 'y', 'z')
+
+    def __init__(self, *args, **kwargs):
+        super(OpenFlexureStage, self).__init__(*args, **kwargs)
+        assert self.readline().startswith("OpenFlexure Motor Board v0.3")
+        time.sleep(2)
+
+    @property
+    def n_axes(self):
+        """The number of axes this stage has."""
+        return len(self.axis_names)
     
-    def move_rel(self, displacement, axis=None):
+    _backlash = None
+    @property
+    def backlash(self):
+        return self._backlash
+
+    @backlash.setter
+    def backlash(self, blsh):
+        if blsh is None:
+            self._backlash = None
+        try:
+            assert len(blsh) == self.n_axes
+            self._backlash = np.array(blsh, dtype=np.int)
+        except:
+            self._backlash = np.array([int(blsh)]*self.n_axes, dtype=np.int)
+
+    def move_rel(self, displacement, axis=None, backlash=True):
+        """Make a relative move, optionally correcting for backlash.
+
+        displacement: integer or array/list of 3 integers
+        axis: None (for 3-axis moves) or one of 'x','y','z'
+        backlash: (default: True) whether to correct for backlash.
+        """
+        if not backlash or self.backlash is None:
+            return self._move_rel_nobacklash(displacement, axis=axis)
+
         if axis is not None:
-            assert axis in ['x', 'y', 'z'], "Axis must be x, y, or z"
+            # backlash correction is easier if we're always in 3D
+            # so this code just converts single-axis moves into all-axis moves.
+            assert axis in self.axis_names, "axis must be one of {}".format(self.axis_names)
+            move = np.zeros(self.n_axes, dtype=np.int)
+            move[np.argmax(np.array(self.axis_names) == axis)] = int(displacement)
+            displacement = move
+
+        initial_move = np.array(displacement, dtype=np.int)
+        # Backlash Correction
+        # This backlash correction strategy ensures we're always approaching the 
+        # end point from the same direction, while minimising the amount of extra
+        # motion.  It's a good option if you're scanning in a line, for example,
+        # as it will kick in when moving to the start of the line, but not for each
+        # point on the line.  
+        # For each axis where we're moving in the *opposite*
+        # direction to self.backlash, we deliberately overshoot:
+        initial_move -= np.where(self.backlash*displacement < 0,
+                                 self.backlash, np.zeros(self.n_axes, dtype=np.int))
+        self._move_rel_nobacklash(initial_move)
+        if np.any(displacement - initial_move != 0):
+            # If backlash correction has kicked in and made us overshoot, move
+            # to the correct end position (i.e. the move we were asked to make)
+            self._move_rel_nobacklash(displacement - initial_move)
+
+    def _move_rel_nobacklash(self, displacement, axis=None):
+        """Just make a move - no messing about with backlash correction!
+        
+        Arguments are as for move_rel, but backlash is False
+        """
+        if axis is not None:
+            assert axis in self.axis_names, "axis must be on of {}".format(self.axis_names)
             self.query("mr{} {}".format(axis, int(displacement)))
         else:
             #TODO: assert displacement is 3 integers
@@ -29,10 +94,33 @@ class OpenFlexureStage(BasicSerialInstrument):
         """De-energise the stepper motor coils"""
         self.query("release")
 
+    def move_abs(self, final, **kwargs):
+        new_position = final#h.verify_vector(final)
+        rel_mov = np.subtract(new_position, self.position)
+        return self.move_rel(rel_mov, **kwargs)
+
+    def focus_rel(self, z):
+        """Move the stage in the Z direction by z micro steps."""
+        self.move_rel([0, 0, z])
+
+    def __enter__(self):
+        """When we use this in a with statement, remember where we started."""
+        self._position_on_enter = self.position
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """The end of the with statement.  Reset position if it went wrong.
+        NB the instrument is closed when the object is deleted, so we don't
+        need to worry about that here.
+        """
+        if type is not None:
+            print "An exception occurred inside a with block, resetting "
+            "position to its value at the start of the with block"
+            self.move_abs(self._position_on_enter)
+        
+
 if __name__ == "__main__":
     s = OpenFlexureStage('COM3')
-
-    print s.readline()
     time.sleep(1)
     #print s.query("mrx 1000")
     #time.sleep(1)


### PR DESCRIPTION
This introduces a precompiler flag to add support for the Adafruit TSL2591 light sensor.  It adds serial commands to work with the gain, integration time, and read the full-spectrum diode.  I have not defined the flag by default so that it will compile and run happily without the sensor.

This also fixes some issues in the Python code by updating it from the openflexure microscope software repo.